### PR TITLE
Replace awssum with official aws-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "publisssh",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "bin": {
     "publisssh": "./bin/publisssh"
   },
   "dependencies": {
     "async": "~0.2.6",
-    "awssum": "~0.12.2",
+    "aws-sdk": "~1.3.0",
     "coffee-script": "~1.4.0",
     "colors": "~0.6.0-1",
     "mime": "~1.2.9",


### PR DESCRIPTION
Node > 0.9.2 tightened some default security settings which causes a lot of the existing S3 libraries to choke on bucket names with periods in them. The official Node SDK handles this case.
