### PR TITLE
Update AWS-SDK version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "publisssh",
+  "description": "Push a site to S3",
   "version": "1.0.1",
   "bin": {
     "publisssh": "./bin/publisssh"
@@ -11,5 +12,11 @@
     "mime": "^1.2.11",
     "optimist": "^0.6.1",
     "wrench": "^1.5.8"
+  },
+  "homepage": "https://github.com/brian-c/publisssh",
+  "bugs": "https://github.com/brian-c/publisssh/issues",
+  "repository": { 
+    "type": "git", 
+    "url": "https://github.com/brian-c/publisssh.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "publisssh": "./bin/publisssh"
   },
   "dependencies": {
-    "aws-sdk": "~2.1.36",
-    "chalk": "^0.5.1",
+    "aws-sdk": "^2.2.25",
+    "chalk": "^1.1.1",
     "iced-coffee-script": "^1.8.0-c",
     "mime": "^1.2.11",
     "optimist": "^0.6.1",


### PR DESCRIPTION
Updates to `aws-sdk` to 2.2.25, which should fix any issues with later Node versions (I've tested up to 5.2.0)

Fixes #3 
